### PR TITLE
set GITHUB_WORKSPACE correctly

### DIFF
--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -29,7 +29,7 @@ docker run \
   -e GITHUB_HEAD_REF \
   -e GITHUB_BASE_REF \
   -e GITHUB_EVENT_NAME \
-  -e GITHUB_WORKSPACE \
+  -e GITHUB_WORKSPACE=/github/workspace \
   -e GITHUB_ACTION \
   -e GITHUB_EVENT_PATH \
   -e RUNNER_OS \

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -20,12 +20,12 @@ docker build . --file $ACT_PATH/Dockerfiles/Dockerfile.$ARCH.$DISTRO --tag multi
 docker run \
   --workdir /github/workspace \
   --rm \
-  -e HOME \
+  -e HOME=/github/home \
   -e GITHUB_REF \
   -e GITHUB_SHA \
   -e GITHUB_REPOSITORY \
   -e GITHUB_ACTOR \
-  -e GITHUB_WORKFLOW \
+  -e GITHUB_WORKFLOW=/github/workflow \
   -e GITHUB_HEAD_REF \
   -e GITHUB_BASE_REF \
   -e GITHUB_EVENT_NAME \


### PR DESCRIPTION
Since we are mounting the current working directory into the docker container using `-v "${PWD}":"/github/workspace"`, we should ensure that `GITHUB_WORKSPACE` points to that same directory as well

Signed-off-by: Davanum Srinivas <davanum@gmail.com>