### PR TITLE
Reduce output of APT in run-on-arch.sh

### DIFF
--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -12,9 +12,9 @@ jobs:
         architecture: armv7
         distribution: ubuntu18.04
         run: |
-          apt update
-          apt install -y libatomic1 libbsd0 clang libicu-dev libcurl4-nss-dev
-          apt install -y curl
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -q
+          apt install -q -y libatomic1 libbsd0 clang libicu-dev libcurl4-nss-dev curl
           curl -OL https://github.com/uraimo/buildSwiftOnARM/releases/download/5.0.3/swift-5.0.3-armv7-Ubuntu1804.tgz
           tar xzf swift-5.0.3-armv7-Ubuntu1804.tgz
           echo "import Glibc;puts(\"Test!\");print(\"Test!!\")" > test.swift

--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -6,8 +6,10 @@ jobs:
     runs-on: ubuntu-18.04
     name: A job to test the multi architecture actions
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Build with Swift on armv7
-      uses: uraimo/run-on-arch-action@master
+      uses: ./
       with:
         architecture: armv7
         distribution: ubuntu18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,9 @@ jobs:
         architecture: aarch64
         distribution: ubuntu18.04
         run: |
-          apt update
-          apt install -y build-essential
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -q
+          apt-get install -q -y build-essential
           uname -a > output.txt
           echo | gcc -v -E - 2>&1 | grep cc1 >> output.txt
           lscpu | grep "Model name:" | sed -r 's/Model name:\s{1,}//g' >> output.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to test the multi architecture action
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Run some commands on arm64
       id: runcmd
-      uses: uraimo/run-on-arch-action@master
+      uses: ./
       with:
         architecture: aarch64
         distribution: ubuntu18.04

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -7,10 +7,11 @@ DISTRO=$2
 COMMANDS=$3
 COMMANDS="${COMMANDS//[$'\t\r\n']+/;}" #Replace newline with ;
 ADDITIONAL_ARGS=$4
+DEBIAN_FRONTEND=noninteractive
 
 # Install support for new archs via qemu
 # Platforms: linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
-sudo apt update -y && sudo apt install -y qemu qemu-user-static
+sudo apt-get update -q -y && sudo apt-get install -q -y qemu qemu-user-static
 
 ACT_PATH=$(dirname $(dirname $(readlink -fm "$0")))
 


### PR DESCRIPTION
Using `apt` in a non-interactive and TTY-less environment emits the following warning:

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

The environment variable `DEBIAN_FRONTEND=noninteractive` will tell APT not to retrieve interactive input from users,
see also [debconf(7) - Frontends](https://manpages.ubuntu.com/manpages/focal/man7/debconf.7.html#frontends).