### PR TITLE
Better dockerRunArgs handling, ensure slug is lowercase, add install parameter

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -40,14 +40,36 @@ jobs:
 
           # Pass some environment variables to the container
           env: | # YAML, but pipe character is necessary
-            artifact_name: sh-${{ matrix.distro }}_${{ matrix.arch }}
+            artifact_name: git-${{ matrix.distro }}_${{ matrix.arch }}
 
           # The shell to run commands with in the container
           shell: /bin/sh
 
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster)
+                apt-get update -q -y
+                apt-get install -q -y git
+                ;;
+              fedora*)
+                dnf -y update
+                dnf -y install git which
+                ;;
+              alpine*)
+                apk update
+                apk add git
+                ;;
+            esac
+
           # Produce a binary artifact and place it in the mounted volume
           run: |
-            cp /bin/sh "/artifacts/${artifact_name}"
+            cp $(which git) "/artifacts/${artifact_name}"
             echo "Produced artifact at /artifacts/${artifact_name}"
 
       - name: Show the artifact

--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -1,4 +1,5 @@
-on: [push]
+name: Advanced Example
+on: [push, pull_request]
 
 jobs:
   build_job:

--- a/.github/workflows/basic-example.yml
+++ b/.github/workflows/basic-example.yml
@@ -1,5 +1,5 @@
-
-on: [push]
+name: Basic Example
+on: [push, pull_request]
 
 jobs:
   armv7_job:

--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -1,5 +1,5 @@
-name: swift-build
-on: [push,pull_request]
+name: Build with Swift on armv7
+on: [push, pull_request]
 
 jobs:
   testactions_job:
@@ -8,7 +8,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Build with Swift on armv7
+    - name: Build
       uses: ./
       with:
         arch: armv7

--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -15,7 +15,7 @@ jobs:
         distro: ubuntu18.04
         githubToken: ${{ github.token }}
         install: |
-          apt-get update -q
+          apt-get update -q -y
           apt install -q -y libatomic1 libbsd0 clang libicu-dev libcurl4-nss-dev curl
           curl -L https://github.com/uraimo/buildSwiftOnARM/releases/download/5.0.3/swift-5.0.3-armv7-Ubuntu1804.tgz -o /root/swift-5.0.3-armv7-Ubuntu1804.tgz
 

--- a/.github/workflows/swift-build.yml
+++ b/.github/workflows/swift-build.yml
@@ -14,11 +14,13 @@ jobs:
         arch: armv7
         distro: ubuntu18.04
         githubToken: ${{ github.token }}
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
+        install: |
           apt-get update -q
           apt install -q -y libatomic1 libbsd0 clang libicu-dev libcurl4-nss-dev curl
-          curl -OL https://github.com/uraimo/buildSwiftOnARM/releases/download/5.0.3/swift-5.0.3-armv7-Ubuntu1804.tgz
+          curl -L https://github.com/uraimo/buildSwiftOnARM/releases/download/5.0.3/swift-5.0.3-armv7-Ubuntu1804.tgz -o /root/swift-5.0.3-armv7-Ubuntu1804.tgz
+
+        run: |
+          cd /root
           tar xzf swift-5.0.3-armv7-Ubuntu1804.tgz
           echo "import Glibc;puts(\"Test!\");print(\"Test!!\")" > test.swift
           ./usr/bin/swiftc test.swift

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Unit Tests
 on: [push, pull_request]
 
 jobs:
@@ -38,41 +38,53 @@ jobs:
         arch: ${{ matrix.arch }}
         distro: ${{ matrix.distro }}
         env: |
-          var_1: value_1
-          var_2: value_2
+          env_arch: ${{ matrix.arch }}
+          env_distro: ${{ matrix.distro }}
 
+        # Test multiple argument formats
         dockerRunArgs: |
           -v "${PWD}/volume_1:/volume_1"
-          -v "${PWD}/volume_2:/volume_2"
+          --volume=${PWD}/volume_2:/volume_2
+          "-v${PWD}/volume_3:/volume_3"
+          -v "${PWD}/volume_4:/volume_4" -v "${PWD}/volume_5:/volume_5"
 
         # Sourced on host, after container build, before container run
         setup: |
           distro_info=$(cat /etc/*-release | tr '[:upper:]' '[:lower:]' | tr '"' ' ' | tr '\n' ' ')
 
-          echo ::set-output name=host_arch::$(uname -m)
-          echo ::set-output name=host_distro_info::$distro_info
-          echo ::set-output name=host_var_1::$var_1
-          echo ::set-output name=host_var_2::$var_2
-          echo ::set-output name=host_shell_options::$-
+          echo ::set-output name=host_arch::"$(uname -m)"
+          echo ::set-output name=host_distro_info::"$distro_info"
+          echo ::set-output name=host_env_arch::"$env_arch"
+          echo ::set-output name=host_env_distro::"$env_distro"
+          echo ::set-output name=host_shell_options::"$-"
 
           # Setup volumes
           mkdir "${PWD}/volume_1"
           touch "${PWD}/volume_1/file_1"
           mkdir "${PWD}/volume_2"
           touch "${PWD}/volume_2/file_2"
+          mkdir "${PWD}/volume_3"
+          touch "${PWD}/volume_3/file_3"
+          mkdir "${PWD}/volume_4"
+          touch "${PWD}/volume_4/file_4"
+          mkdir "${PWD}/volume_5"
+          touch "${PWD}/volume_5/file_5"
 
         # Run on container
         run: |
           distro_info=$(cat /etc/*-release | tr '[:upper:]' '[:lower:]' | sed 's/"//g' | tr '\n' ';')
 
-          echo ::set-output name=arch::$(uname -m)
-          echo ::set-output name=distro_info::$distro_info
-          echo ::set-output name=shebang::$(head -n 1 "$0")
-          echo ::set-output name=var_1::$var_1
-          echo ::set-output name=var_2::$var_2
-          echo ::set-output name=volume_1_ls::$(ls /volume_1 || true)
-          echo ::set-output name=volume_2_ls::$(ls /volume_2 || true)
-          echo ::set-output name=shell_options::$-
+          echo ::set-output name=arch::"$(uname -m)"
+          echo ::set-output name=distro_info::"$distro_info"
+          echo ::set-output name=shebang::"$(head -n 1 "$0")"
+          echo ::set-output name=env_arch::"$env_arch"
+          echo ::set-output name=env_distro::"$env_distro"
+          echo ::set-output name=volume_1_ls::"$(ls /volume_1 || true)"
+          echo ::set-output name=volume_2_ls::"$(ls /volume_2 || true)"
+          echo ::set-output name=volume_3_ls::"$(ls /volume_3 || true)"
+          echo ::set-output name=volume_4_ls::"$(ls /volume_4 || true)"
+          echo ::set-output name=volume_5_ls::"$(ls /volume_5 || true)"
+          echo ::set-output name=shell_options::"$-"
 
     - name: Assert setup script runs on host (check arch info)
       run: |
@@ -90,14 +102,14 @@ jobs:
 
     - name: Assert setup script receives environment variables
       run: |
-        var_1="${{ steps.build.outputs.host_var_1 }}"
-        var_2="${{ steps.build.outputs.host_var_2 }}"
+        arch="${{ steps.build.outputs.host_env_arch }}"
+        distro="${{ steps.build.outputs.host_env_distro }}"
 
-        echo "Assert var_1: '$var_1' == 'value_1'"
-        test "$var_1" == "value_1"
+        echo "Assert env_arch: '$arch' == '${{ matrix.arch }}'"
+        test "$arch" == "${{ matrix.arch }}"
 
-        echo "Assert var_2: '$var_2' == 'value_2'"
-        test "$var_1" == "value_1"
+        echo "Assert env_distro: '$distro' == '${{ matrix.distro }}'"
+        test "$distro" == "${{ matrix.distro }}"
 
     - name: Assert job would fail on setup script error
       run: |
@@ -137,14 +149,14 @@ jobs:
 
     - name: Assert container receives environment variables
       run: |
-        var_1="${{ steps.build.outputs.var_1 }}"
-        var_2="${{ steps.build.outputs.var_2 }}"
+        arch="${{ steps.build.outputs.env_arch }}"
+        distro="${{ steps.build.outputs.env_distro }}"
 
-        echo "Assert var_1: '$var_1' == 'value_1'"
-        test "$var_1" == "value_1"
+        echo "Assert env_arch: '$arch' == '${{ matrix.arch }}'"
+        test "$arch" == "${{ matrix.arch }}"
 
-        echo "Assert var_2: '$var_2' == 'value_2'"
-        test "$var_1" == "value_1"
+        echo "Assert env_distro: '$distro' == '${{ matrix.distro }}'"
+        test "$distro" == "${{ matrix.distro }}"
 
     - name: Assert job would fail on run script error
       run: |
@@ -159,12 +171,24 @@ jobs:
       run: |
         volume_1_ls="${{ steps.build.outputs.volume_1_ls }}"
         volume_2_ls="${{ steps.build.outputs.volume_2_ls }}"
+        volume_3_ls="${{ steps.build.outputs.volume_3_ls }}"
+        volume_4_ls="${{ steps.build.outputs.volume_4_ls }}"
+        volume_5_ls="${{ steps.build.outputs.volume_5_ls }}"
 
         echo "Assert volume_1_ls: '$volume_1_ls' == 'file_1'"
         test "$volume_1_ls" == "file_1"
 
         echo "Assert volume_2_ls: '$volume_2_ls' == 'file_2'"
         test "$volume_2_ls" == "file_2"
+
+        echo "Assert volume_3_ls: '$volume_3_ls' == 'file_3'"
+        test "$volume_3_ls" == "file_3"
+
+        echo "Assert volume_4_ls: '$volume_4_ls' == 'file_4'"
+        test "$volume_4_ls" == "file_4"
+
+        echo "Assert volume_5_ls: '$volume_5_ls' == 'file_5'"
+        test "$volume_5_ls" == "file_5"
 
     - name: Assert container determines correct default shell for distro
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,24 @@ jobs:
           mkdir "${PWD}/volume_5"
           touch "${PWD}/volume_5/file_5"
 
+        # Install some dependencies in the container, to be cached in a docker
+        # image layer.
+        install: |
+          case "${{ matrix.distro }}" in
+            ubuntu*|jessie|stretch|buster)
+              apt-get update -q -y
+              apt-get install -q -y git
+              ;;
+            fedora*)
+              dnf -y update
+              dnf -y install git which
+              ;;
+            alpine*)
+              apk update
+              apk add git
+              ;;
+          esac
+
         # Run on container
         run: |
           distro_info=$(cat /etc/*-release | tr '[:upper:]' '[:lower:]' | sed 's/"//g' | tr '\n' ';')
@@ -84,6 +102,7 @@ jobs:
           echo ::set-output name=volume_3_ls::"$(ls /volume_3 || true)"
           echo ::set-output name=volume_4_ls::"$(ls /volume_4 || true)"
           echo ::set-output name=volume_5_ls::"$(ls /volume_5 || true)"
+          echo ::set-output name=git_path::"$(which git)"
           echo ::set-output name=shell_options::"$-"
 
     - name: Assert setup script runs on host (check arch info)
@@ -110,6 +129,13 @@ jobs:
 
         echo "Assert env_distro: '$distro' == '${{ matrix.distro }}'"
         test "$distro" == "${{ matrix.distro }}"
+
+    - name: Assert install script runs
+      run: |
+        git_path="${{ steps.build.outputs.git_path }}"
+
+        echo "Assert git path: '$git_path' == '/usr/bin/git'"
+        test "$git_path" == "/usr/bin/git"
 
     - name: Assert job would fail on setup script error
       run: |

--- a/Dockerfiles/Dockerfile.aarch64.alpine_latest
+++ b/Dockerfiles/Dockerfile.aarch64.alpine_latest
@@ -1,1 +1,4 @@
 FROM arm64v8/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.buster
+++ b/Dockerfiles/Dockerfile.aarch64.buster
@@ -1,1 +1,4 @@
 FROM arm64v8/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.fedora_latest
+++ b/Dockerfiles/Dockerfile.aarch64.fedora_latest
@@ -1,1 +1,4 @@
 FROM arm64v8/fedora:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.stretch
+++ b/Dockerfiles/Dockerfile.aarch64.stretch
@@ -1,1 +1,4 @@
 FROM arm64v8/debian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu16.04
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu16.04
@@ -1,1 +1,4 @@
 FROM arm64v8/ubuntu:16.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu18.04
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu18.04
@@ -1,2 +1,4 @@
 FROM arm64v8/ubuntu:18.04
 
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu20.04
@@ -1,2 +1,5 @@
 FROM arm64v8/ubuntu:20.04
 
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv6.alpine_latest
+++ b/Dockerfiles/Dockerfile.armv6.alpine_latest
@@ -1,1 +1,4 @@
 FROM balenalib/raspberry-pi-alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv6.buster
+++ b/Dockerfiles/Dockerfile.armv6.buster
@@ -1,1 +1,4 @@
 FROM balenalib/rpi-raspbian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv6.jessie
+++ b/Dockerfiles/Dockerfile.armv6.jessie
@@ -1,1 +1,4 @@
 FROM balenalib/rpi-raspbian:jessie
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv6.stretch
+++ b/Dockerfiles/Dockerfile.armv6.stretch
@@ -1,1 +1,4 @@
 FROM balenalib/rpi-raspbian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.alpine_latest
+++ b/Dockerfiles/Dockerfile.armv7.alpine_latest
@@ -1,1 +1,4 @@
 FROM arm32v7/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.buster
+++ b/Dockerfiles/Dockerfile.armv7.buster
@@ -1,1 +1,4 @@
 FROM arm32v7/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.jessie
+++ b/Dockerfiles/Dockerfile.armv7.jessie
@@ -1,1 +1,4 @@
 FROM arm32v7/debian:jessie
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.stretch
+++ b/Dockerfiles/Dockerfile.armv7.stretch
@@ -1,1 +1,4 @@
 FROM arm32v7/debian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu16.04
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu16.04
@@ -1,1 +1,4 @@
 FROM arm32v7/ubuntu:16.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu18.04
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu18.04
@@ -1,1 +1,4 @@
 FROM arm32v7/ubuntu:18.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu20.04
@@ -1,1 +1,4 @@
 FROM arm32v7/ubuntu:20.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.alpine_latest
+++ b/Dockerfiles/Dockerfile.ppc64le.alpine_latest
@@ -1,1 +1,4 @@
 FROM ppc64le/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.buster
+++ b/Dockerfiles/Dockerfile.ppc64le.buster
@@ -1,1 +1,4 @@
 FROM ppc64le/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.fedora_latest
+++ b/Dockerfiles/Dockerfile.ppc64le.fedora_latest
@@ -1,1 +1,4 @@
 FROM ppc64le/fedora:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.jessie
+++ b/Dockerfiles/Dockerfile.ppc64le.jessie
@@ -1,1 +1,4 @@
 FROM ppc64le/debian:jessie
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.stretch
+++ b/Dockerfiles/Dockerfile.ppc64le.stretch
@@ -1,1 +1,4 @@
 FROM ppc64le/debian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu16.04
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu16.04
@@ -1,1 +1,4 @@
 FROM ppc64le/ubuntu:16.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu18.04
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu18.04
@@ -1,1 +1,4 @@
 FROM ppc64le/ubuntu:18.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu20.04
@@ -1,1 +1,4 @@
 FROM ppc64le/ubuntu:20.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.alpine_latest
+++ b/Dockerfiles/Dockerfile.s390x.alpine_latest
@@ -1,1 +1,4 @@
 FROM s390x/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.buster
+++ b/Dockerfiles/Dockerfile.s390x.buster
@@ -1,1 +1,4 @@
 FROM s390x/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.fedora_latest
+++ b/Dockerfiles/Dockerfile.s390x.fedora_latest
@@ -1,1 +1,4 @@
 FROM s390x/fedora:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.jessie
+++ b/Dockerfiles/Dockerfile.s390x.jessie
@@ -1,1 +1,4 @@
 FROM s390x/debian:jessie
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.stretch
+++ b/Dockerfiles/Dockerfile.s390x.stretch
@@ -1,1 +1,4 @@
 FROM s390x/debian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu16.04
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu16.04
@@ -1,1 +1,4 @@
 FROM s390x/ubuntu:16.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu18.04
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu18.04
@@ -1,1 +1,4 @@
 FROM s390x/ubuntu:18.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu20.04
@@ -1,1 +1,4 @@
 FROM s390x/ubuntu:20.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ This action requires three input parameters:
 
 The action also accepts some optional input parameters:
 
-* `githubToken`: Your GitHub token, used for caching Docker images in your project's public package registry. Usually this would just be `${{ github.token }}`. This speeds up builds and is highly recommended.
+* `githubToken`: Your GitHub token, used for caching Docker images in your project's public package registry. Usually this would just be `${{ github.token }}`. This speeds up subsequent builds and is highly recommended.
 * `env`: Environment variables to propagate to the container. YAML, but must begin with a `|` character. These variables will be available in both run and setup.
 * `shell`: The shell to run commands with in the container. Default: `/bin/sh` on Alpine, `/bin/bash` for other distros.
 * `dockerRunArgs`: Additional arguments to pass to `docker run`, such as volume mappings. See [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run).
 * `setup`: Shell commands to execute on the host before running the container, such as creating directories for volume mappings.
+* `install`: Shell commands to execute in the container as part of `docker build`, such as installing dependencies. This speeds up subsequent builds if `githubToken` is also used, but note that the image layer will be publicly available in your projects GitHub Package Registry, so make sure the resulting image does not have any secrets cached in logs or state.
 
 ### Basic example
 
@@ -104,14 +105,36 @@ jobs:
 
           # Pass some environment variables to the container
           env: | # YAML, but pipe character is necessary
-            artifact_name: sh-${{ matrix.distro }}_${{ matrix.arch }}
+            artifact_name: git-${{ matrix.distro }}_${{ matrix.arch }}
 
           # The shell to run commands with in the container
           shell: /bin/sh
 
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster)
+                apt-get update -q -y
+                apt-get install -q -y git
+                ;;
+              fedora*)
+                dnf -y update
+                dnf -y install git which
+                ;;
+              alpine*)
+                apk update
+                apk add git
+                ;;
+            esac
+
           # Produce a binary artifact and place it in the mounted volume
           run: |
-            cp /bin/sh "/artifacts/${artifact_name}"
+            cp $(which git) "/artifacts/${artifact_name}"
             echo "Produced artifact at /artifacts/${artifact_name}"
 
       - name: Show the artifact

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The action also accepts some optional input parameters:
 A basic example that sets an output variable for use in subsequent steps:
 
 ```yaml
-on: [push]
+on: [push, pull_request]
 
 jobs:
   armv7_job:
@@ -36,7 +36,7 @@ jobs:
     name: Build on ubuntu-18.04 armv7
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.1
+      - uses: uraimo/run-on-arch-action@v2.0.2
         name: Run commands
         id: runcmd
         with:
@@ -63,7 +63,7 @@ jobs:
 This shows how to use a matrix to produce platform-specific artifacts, and includes example values for the optional input parameters `setup`, `shell`, `env`, and `dockerRunArgs`.
 
 ```yaml
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build_job:
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.1
+      - uses: uraimo/run-on-arch-action@v2.0.2
         name: Build artifact
         id: build
         with:

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: 'Shell commands to execute on the host before running the container, such as creating directories for volume mappings. See README for example usage.'
     required: false
     default: ''
+  install:
+    description: 'Shell commands to execute in the container as part of docker build, such as installing dependencies. This speeds up subsequent builds if githubToken is also used, but note that the image layer will be publicly available in your projects GitHub Package Registry, so make sure the resulting image does not have any secrets cached in logs or state.'
+    required: false
+    default: ''
 
 runs:
   using: 'node12'

--- a/node_modules/shlex/.eslintrc.json
+++ b/node_modules/shlex/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "extends": "standard",
+    "rules": {
+      "camelcase": "off",
+      "no-multiple-empty-lines": "off"
+    }
+}

--- a/node_modules/shlex/.github/workflows/nodejs.yml
+++ b/node_modules/shlex/.github/workflows/nodejs.yml
@@ -1,0 +1,26 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true

--- a/node_modules/shlex/LICENSE
+++ b/node_modules/shlex/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Ryan Govostes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/shlex/README.md
+++ b/node_modules/shlex/README.md
@@ -1,0 +1,42 @@
+# node-shlex
+
+![Build Status](https://github.com/rgov/node-shlex/workflows/Node.js%20CI/badge.svg)
+
+`node-shlex` is a Node.js module for quoting and parsing shell commands.
+
+The API was inspired by the [`shlex`][pyshlex] module from the Python Standard 
+Library. However, the Python implementation is fairly complex, and supports a
+confusing matrix of modes that is not replicated here. `node-shlex` always
+operates in what the Python module calls "POSIX mode."
+
+[pyshlex]: https://docs.python.org/3/library/shlex.html
+
+As of version 2.0.0, Bash's [ANSI C strings][ansi-c] (`$'x'`) and
+[locale-specific translation strings][locale] (`$"x"`) are supported. This
+diverges from the Python `shlex` behavior but makes parsing more accurate.
+
+[ansi-c]: https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
+[locale]: https://www.gnu.org/software/bash/manual/html_node/Locale-Translation.html
+
+Note that `node-shlex` does not attempt to split on or otherwise parse 
+operators (such as `2>/dev/null`), and it does not perform variable
+interpolation.
+
+## Usage
+
+### `shlex.quote()`
+
+```node
+var quote = require("shlex").quote
+quote("abc")      // returns: abc
+quote("abc def")  // returns: 'abc def'
+quote("can't")    // returns: 'can'"'"'t'
+```
+
+### `shlex.split()`
+
+```node
+var split = require("shlex").split
+split('ls -al /')  // returns: [ 'ls', '-al', '/' ]
+split('rm -f "/Volumes/Macintosh HD"')  // returns [ 'rm', '-f', '/Volumes/Macintosh HD' ]
+```

--- a/node_modules/shlex/package.json
+++ b/node_modules/shlex/package.json
@@ -1,0 +1,66 @@
+{
+  "_from": "shlex@2.0.2",
+  "_id": "shlex@2.0.2",
+  "_inBundle": false,
+  "_integrity": "sha512-i4p9nNXgBTILspHwZlBCNsZzwuVWW8SFx5dyIONrjL0R+AbMOPbg7ndqgGfjYivkYRTtZMKqIT8HT+QyOhPQWA==",
+  "_location": "/shlex",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "shlex@2.0.2",
+    "name": "shlex",
+    "escapedName": "shlex",
+    "rawSpec": "2.0.2",
+    "saveSpec": null,
+    "fetchSpec": "2.0.2"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/shlex/-/shlex-2.0.2.tgz",
+  "_shasum": "debf51a145f1df9e7cb7cce04340ccb45120092d",
+  "_spec": "shlex@2.0.2",
+  "_where": "/Users/elijahrutschman/Development/run-on-arch-action",
+  "author": {
+    "name": "Ryan Govostes"
+  },
+  "bugs": {
+    "url": "https://github.com/rgov/node-shlex/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Node.js port of Python's shlex shell-like lexer",
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "eslint": "^5.15.3",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "mocha": "^5.2.0"
+  },
+  "homepage": "https://github.com/rgov/node-shlex#readme",
+  "keywords": [
+    "shell",
+    "command-line",
+    "cli",
+    "lexer"
+  ],
+  "license": "MIT",
+  "main": "shlex.js",
+  "name": "shlex",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rgov/node-shlex.git"
+  },
+  "scripts": {
+    "posttest": "eslint .",
+    "test": "mocha"
+  },
+  "types": "shlex.d.ts",
+  "version": "2.0.2"
+}

--- a/node_modules/shlex/shlex.d.ts
+++ b/node_modules/shlex/shlex.d.ts
@@ -1,0 +1,2 @@
+export function split(s: string): string[];
+export function quote(s: string): string;

--- a/node_modules/shlex/shlex.js
+++ b/node_modules/shlex/shlex.js
@@ -1,0 +1,284 @@
+'use strict'
+
+/*
+  Port of a subset of the features of CPython's shlex module, which provides a
+  shell-like lexer. Original code by Eric S. Raymond and other contributors.
+*/
+
+class Shlexer {
+  constructor (string) {
+    this.i = 0
+    this.string = string
+
+    /**
+     * Characters that will be considered whitespace and skipped. Whitespace
+     * bounds tokens. By default, includes space, tab, linefeed and carriage
+     * return.
+     */
+    this.whitespace = ' \t\r\n'
+
+    /**
+     * Characters that will be considered string quotes. The token accumulates
+     * until the same quote is encountered again (thus, different quote types
+     * protect each other as in the shell.) By default, includes ASCII single
+     * and double quotes.
+     */
+    this.quotes = `'"`
+
+    /**
+     * Characters that will be considered as escape. Just `\` by default.
+     */
+    this.escapes = '\\'
+
+    /**
+     * The subset of quote types that allow escaped characters. Just `"` by default.
+     */
+    this.escapedQuotes = '"'
+
+    /**
+     * Whether to support ANSI C-style $'' quotes
+     * https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
+     */
+    this.ansiCQuotes = true
+
+    /**
+     * Whether to support localized $"" quotes
+     * https://www.gnu.org/software/bash/manual/html_node/Locale-Translation.html
+     *
+     * The behavior is as if the current locale is set to C or POSIX, i.e., the
+     * contents are not translated.
+     */
+    this.localeQuotes = true
+
+    this.debug = false
+  }
+
+  readChar () {
+    return this.string.charAt(this.i++)
+  }
+
+  processEscapes (string, quote, isAnsiCQuote) {
+    if (!isAnsiCQuote && !this.escapedQuotes.includes(quote)) {
+      // This quote type doesn't support escape sequences
+      return string
+    }
+
+    // We need to form a regex that matches any of the escape characters,
+    // without interpreting any of the characters as a regex special character.
+    let anyEscape = '[' + this.escapes.replace(/(.)/g, '\\$1') + ']'
+
+    // In regular quoted strings, we can only escape an escape character, and
+    // the quote character itself.
+    if (!isAnsiCQuote && this.escapedQuotes.includes(quote)) {
+      let re = new RegExp(
+        anyEscape + '(' + anyEscape + '|\\' + quote + ')', 'g')
+      return string.replace(re, '$1')
+    }
+
+    // ANSI C quoted strings support a wide variety of escape sequences
+    if (isAnsiCQuote) {
+      let patterns = {
+        // Literal characters
+        '([\\\\\'"?])': (x) => x,
+
+        // Non-printable ASCII characters
+        'a': () => '\x07',
+        'b': () => '\x08',
+        'e|E': () => '\x1b',
+        'f': () => '\x0c',
+        'n': () => '\x0a',
+        'r': () => '\x0d',
+        't': () => '\x09',
+        'v': () => '\x0b',
+
+        // Octal bytes
+        '([0-7]{1,3})': (x) => String.fromCharCode(parseInt(x, 8)),
+
+        // Hexadecimal bytes
+        'x([0-9a-fA-F]{1,2})': (x) => String.fromCharCode(parseInt(x, 16)),
+
+        // Unicode code units
+        'u([0-9a-fA-F]{1,4})': (x) => String.fromCharCode(parseInt(x, 16)),
+        'U([0-9a-fA-F]{1,8})': (x) => String.fromCharCode(parseInt(x, 16)),
+
+        // Control characters
+        // https://en.wikipedia.org/wiki/Control_character#How_control_characters_map_to_keyboards
+        'c(.)': (x) => {
+          if (x === '?') {
+            return '\x7f'
+          } else if (x === '@') {
+            return '\x00'
+          } else {
+            return String.fromCharCode(x.charCodeAt(0) & 31)
+          }
+        }
+      }
+
+      // Construct an uber-RegEx that catches all of the above pattern
+      let re = new RegExp(
+        anyEscape + '(' + Object.keys(patterns).join('|') + ')', 'g')
+
+      // For each match, figure out which subpattern matched, and apply the
+      // corresponding function
+      return string.replace(re, function (m, p1) {
+        for (let matched in patterns) {
+          let mm = new RegExp('^' + matched + '$').exec(p1)
+          if (mm === null) {
+            continue
+          }
+
+          return patterns[matched].apply(null, mm.slice(1))
+        }
+      })
+    }
+
+    // Should not get here
+    return undefined
+  }
+
+  * [Symbol.iterator] () {
+    let inQuote = false
+    let inDollarQuote = false
+    let escaped = false
+    let lastDollar = -2 // position of last dollar sign we saw
+    let token
+
+    if (this.debug) {
+      console.log('full input:', '>' + this.string + '<')
+    }
+
+    while (true) {
+      const pos = this.i
+      const char = this.readChar()
+
+      if (this.debug) {
+        console.log(
+          'position:', pos,
+          'input:', '>' + char + '<',
+          'accumulated:', token,
+          'inQuote:', inQuote,
+          'inDollarQuote:', inDollarQuote,
+          'lastDollar:', lastDollar,
+          'escaped:', escaped
+        )
+      }
+
+      // Ran out of characters, we're done
+      if (char === '') {
+        if (inQuote) { throw new Error('Got EOF while in a quoted string') }
+        if (escaped) { throw new Error('Got EOF while in an escape sequence') }
+        if (token !== undefined) { yield token }
+        return
+      }
+
+      // We were in an escape sequence, complete it
+      if (escaped) {
+        if (char === '\n') {
+          // An escaped newline just means to continue the command on the next
+          // line. We just need to ignore it.
+        } else if (inQuote) {
+          // If we are in a quote, just accumulate the whole escape sequence,
+          // as we will interpret escape sequences later.
+          token = (token || '') + escaped + char
+        } else {
+          // Just use the literal character
+          token = (token || '') + char
+        }
+
+        escaped = false
+        continue
+      }
+
+      if (this.escapes.includes(char)) {
+        if (!inQuote || inDollarQuote !== false || this.escapedQuotes.includes(inQuote)) {
+          // We encountered an escape character, which is going to affect how
+          // we treat the next character.
+          escaped = char
+          continue
+        } else {
+          // This string type doesn't use escape characters. Ignore for now.
+        }
+      }
+
+      // We were in a string
+      if (inQuote !== false) {
+        // String is finished. Don't grab the quote character.
+        if (char === inQuote) {
+          token = this.processEscapes(token, inQuote, inDollarQuote === '\'')
+          inQuote = false
+          inDollarQuote = false
+          continue
+        }
+
+        // String isn't finished yet, accumulate the character
+        token = (token || '') + char
+        continue
+      }
+
+      // This is the start of a new string, don't accumulate the quotation mark
+      if (this.quotes.includes(char)) {
+        inQuote = char
+        if (lastDollar === pos - 1) {
+          if (char === '\'' && !this.ansiCQuotes) {
+            // Feature not enabled
+          } else if (char === '"' && !this.localeQuotes) {
+            // Feature not enabled
+          } else {
+            inDollarQuote = char
+          }
+        }
+
+        token = (token || '') // fixes blank string
+
+        if (inDollarQuote !== false) {
+          // Drop the opening $ we captured before
+          token = token.slice(0, -1)
+        }
+
+        continue
+      }
+
+      // This is a dollar sign, record that we saw it in case it's the start of
+      // an ANSI C or localized string
+      if (inQuote === false && char === '$') {
+        lastDollar = pos
+      }
+
+      // This is whitespace, so yield the token if we have one
+      if (this.whitespace.includes(char)) {
+        if (token !== undefined) { yield token }
+        token = undefined
+        continue
+      }
+
+      // Otherwise, accumulate the character
+      token = (token || '') + char
+    }
+  }
+}
+
+
+/**
+ * Splits a given string using shell-like syntax.
+ *
+ * @param {String} s String to split.
+ * @returns {String[]}
+ */
+exports.split = function (s) {
+  return Array.from(new Shlexer(s))
+}
+
+/**
+ * Escapes a potentially shell-unsafe string using quotes.
+ *
+ * @param {String} s String to quote
+ * @returns {String}
+ */
+exports.quote = function (s) {
+  if (s === '') { return '\'\'' }
+
+  var unsafeRe = /[^\w@%\-+=:,./]/
+  if (!unsafeRe.test(s)) { return s }
+
+  return '\'' + s.replace(/'/g, '\'"\'"\'') + '\''
+}

--- a/node_modules/shlex/test/test.ts
+++ b/node_modules/shlex/test/test.ts
@@ -1,0 +1,8 @@
+import * as shlex from '../'
+
+shlex.quote('test text')
+shlex.split('test text "multi word thing"')
+
+// Should error
+shlex.quote()
+shlex.split()

--- a/node_modules/shlex/test/test_quote.js
+++ b/node_modules/shlex/test/test_quote.js
@@ -1,0 +1,39 @@
+/* eslint-env mocha */
+'use strict'
+
+const { assert } = require('chai')
+const shlex = require('../shlex')
+
+describe('shlex.quote()', function () {
+  const safeUnquoted = 'abcdefghijklmnopqrstuvwxyz' +
+                       'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+                       '0123456789' +
+                       '@%_-+=:,./'
+  const unicodeSample = '\xe9\xe0\xdf' // e + acute accent, a + grave, sharp s
+  const unsafe = '"`$\\!' + unicodeSample
+
+  it('should escape the empty string', function () {
+    assert.equal(shlex.quote(''), '\'\'')
+  })
+
+  it('should not escape safe strings', function () {
+    assert.equal(shlex.quote(safeUnquoted), safeUnquoted)
+  })
+
+  it('should escape strings containing spaces', function () {
+    assert.equal(shlex.quote('test file name'), "'test file name'")
+  })
+
+  it('should escape unsafe characters', function () {
+    for (var char of unsafe) {
+      const input = 'test' + char + 'file'
+      const expected = '\'' + input + '\''
+
+      assert.equal(shlex.quote(input), expected)
+    }
+  })
+
+  it('should escape single quotes', function () {
+    assert.equal(shlex.quote('test\'file'), '\'test\'"\'"\'file\'')
+  })
+})

--- a/node_modules/shlex/test/test_split.js
+++ b/node_modules/shlex/test/test_split.js
@@ -1,0 +1,146 @@
+/* eslint-env mocha */
+'use strict'
+
+const { assert } = require('chai')
+const shlex = require('../shlex')
+
+describe('shlex.split()', function () {
+  // The original test data set was from shellwords, by Hartmut Goebel
+
+  const posixTestcases = [
+    ['x', 'x'],
+    ['foo bar', 'foo', 'bar'],
+    [' foo bar', 'foo', 'bar'],
+    [' foo bar ', 'foo', 'bar'],
+    ['foo   bar    bla     fasel', 'foo', 'bar', 'bla', 'fasel'],
+    ['x y  z              xxxx', 'x', 'y', 'z', 'xxxx'],
+    ['\\x bar', 'x', 'bar'],
+    ['\\ x bar', ' x', 'bar'],
+    ['\\ bar', ' bar'],
+    ['foo \\x bar', 'foo', 'x', 'bar'],
+    ['foo \\ x bar', 'foo', ' x', 'bar'],
+    ['foo \\ bar', 'foo', ' bar'],
+    ['foo "bar" bla', 'foo', 'bar', 'bla'],
+    ['"foo" "bar" "bla"', 'foo', 'bar', 'bla'],
+    ['"foo" bar "bla"', 'foo', 'bar', 'bla'],
+    ['"foo" bar bla', 'foo', 'bar', 'bla'],
+    ["foo 'bar' bla", 'foo', 'bar', 'bla'],
+    ["'foo' 'bar' 'bla'", 'foo', 'bar', 'bla'],
+    ["'foo' bar 'bla'", 'foo', 'bar', 'bla'],
+    ["'foo' bar bla", 'foo', 'bar', 'bla'],
+    ['blurb foo"bar"bar"fasel" baz', 'blurb', 'foobarbarfasel', 'baz'],
+    ["blurb foo'bar'bar'fasel' baz", 'blurb', 'foobarbarfasel', 'baz'],
+    ['""', ''],
+    ["''", ''],
+    ['foo "" bar', 'foo', '', 'bar'],
+    ["foo '' bar", 'foo', '', 'bar'],
+    ['foo "" "" "" bar', 'foo', '', '', '', 'bar'],
+    ["foo '' '' '' bar", 'foo', '', '', '', 'bar'],
+    ['\\"', '"'],
+    ['"\\""', '"'],
+    ['"foo\\ bar"', 'foo\\ bar'],
+    ['"foo\\\\ bar"', 'foo\\ bar'],
+    ['"foo\\\\ bar\\""', 'foo\\ bar"'],
+    ['"foo\\\\" bar\\"', 'foo\\', 'bar"'],
+    ['"foo\\\\ bar\\" dfadf"', 'foo\\ bar" dfadf'],
+    ['"foo\\\\\\ bar\\" dfadf"', 'foo\\\\ bar" dfadf'],
+    ['"foo\\\\\\x bar\\" dfadf"', 'foo\\\\x bar" dfadf'],
+    ['"foo\\x bar\\" dfadf"', 'foo\\x bar" dfadf'],
+    ["\\'", "'"],
+    ["'foo\\ bar'", 'foo\\ bar'],
+    ["'foo\\\\ bar'", 'foo\\\\ bar'],
+    ["\"foo\\\\\\x bar\\\" df'a\\ 'df\"", "foo\\\\x bar\" df'a\\ 'df"],
+    ['\\"foo', '"foo'],
+    ['\\"foo\\x', '"foox'],
+    ['"foo\\x"', 'foo\\x'],
+    ['"foo\\ "', 'foo\\ '],
+    ['foo\\ xx', 'foo xx'],
+    ['foo\\ x\\x', 'foo xx'],
+    ['foo\\ x\\x\\"', 'foo xx"'],
+    ['"foo\\ x\\x"', 'foo\\ x\\x'],
+    ['"foo\\ x\\x\\\\"', 'foo\\ x\\x\\'],
+    ['"foo\\ x\\x\\\\""foobar"', 'foo\\ x\\x\\foobar'],
+    ["\"foo\\ x\\x\\\\\"\\'\"foobar\"", "foo\\ x\\x\\'foobar"],
+    ["\"foo\\ x\\x\\\\\"\\'\"fo'obar\"", "foo\\ x\\x\\'fo'obar"],
+    ["\"foo\\ x\\x\\\\\"\\'\"fo'obar\" 'don'\\''t'", "foo\\ x\\x\\'fo'obar", "don't"],
+    ["\"foo\\ x\\x\\\\\"\\'\"fo'obar\" 'don'\\''t' \\\\", "foo\\ x\\x\\'fo'obar", "don't", '\\'],
+    ["'foo\\ bar'", 'foo\\ bar'],
+    ["'foo\\\\ bar'", 'foo\\\\ bar'],
+    ['foo\\ bar', 'foo bar'],
+    // ["foo#bar\nbaz", "foo", "baz"], // FIXME: Comments are not implemented
+    [':-) ;-)', ':-)', ';-)'],
+    ['\u00e1\u00e9\u00ed\u00f3\u00fa', '\u00e1\u00e9\u00ed\u00f3\u00fa'],
+    ['hello \\\n world', 'hello', 'world']
+  ]
+
+  const ansiCTestcases = [
+    ['$\'x\'', 'x'], // non-escaped character
+    ['$\'\\a\'', '\x07'], // alert (bell)
+    ['$\'\\b\'', '\x08'], // backspace
+    ['$\'\\e\'', '\x1b'], // escape character
+    ['$\'\\E\'', '\x1b'], // escape character
+    ['$\'\\f\'', '\x0c'], // form feed / new page
+    ['$\'\\n\'', '\x0a'], // newline
+    ['$\'\\r\'', '\x0d'], // carriage return
+    ['$\'\\t\'', '\x09'], // horizontal tab
+    ['$\'\\v\'', '\x0b'], // vertical tab
+    ['$\'\\\\\'', '\\'], // backslash
+    ['$\'\\\'\'', '\''], // single quote
+    ['$\'\\"\'', '"'], // double quote
+    ['$\'\\?\'', '?'], // question mark
+    ['$\'\\79\'', '\x07\x39'], // octal + non-octal
+    ['$\'\\07\'', '\x07'], // octal, zero prefix
+    ['$\'\\xfx\'', '\x0f\x78'], // hex (one digit) + non-hex
+    ['$\'\\xffx\'', '\xff\x78'], // hex (two digits) + non-hex
+    ['$\'\\xxx\'', '\\xxx'], // invalid hex
+    ['$\'\\u2603\'', '☃'], // unicode character
+    ['$\'\\U2603\'', '☃'], // unicode character
+    ['$\'\\ca\'', '\x01'], // control-a character
+    ['$\'\\cA\'', '\x01'], // control-A character, same as above
+    ['$\'\\c@\'', '\x00'], // control-@ character: null
+    ['$\'\\c?\'', '\x7f'], // control-? character: del
+    ['$\'\\\\x30\'', '\\x30'],
+    ['x$\'y\'z', 'xyz'],
+    ['"x"$\'y\'"z"', 'xyz'],
+    ['$\'x\'"y"$\'z\'', 'xyz'],
+    ['x"$\'y\'"z', 'x$\'y\'z']
+  ]
+
+  const localeTestcases = [
+    ['$"x"', 'x'], // non-escaped character
+    ['$"\\""', '"'], // escaped quotation mark
+    ['$"\\\\"', '\\'], // escaped escape character
+    ['$"\\x33"', '\\x33'], // other escape sequences do not work
+    ['x$"y"z', 'xyz'],
+    ['"x"$"y""z"', 'xyz'],
+    ['$"x""y"$"z"', 'xyz'],
+    ['x"$"y""z', 'x$yz']
+  ]
+
+  it('should split according to POSIX rules', function () {
+    posixTestcases.forEach(function (test) {
+      const input = test[0]
+      const expected = test.slice(1)
+
+      assert.deepEqual(shlex.split(input), expected)
+    })
+  })
+
+  it('should split ANSI C strings', function () {
+    ansiCTestcases.forEach(function (test) {
+      const input = test[0]
+      const expected = test.slice(1)
+
+      assert.deepEqual(shlex.split(input), expected)
+    })
+  })
+
+  it('should split localized strings', function () {
+    localeTestcases.forEach(function (test) {
+      const input = test[0]
+      const expected = test.slice(1)
+
+      assert.deepEqual(shlex.split(input), expected)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "run-on-arch",
-  "version": "1.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,6 +13,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.0.1.tgz",
       "integrity": "sha512-nvFkxwiicvpzNiCBF4wFBDfnBvi7xp/as7LE1hBxBxKG2L29+gkIPBiLKMVORL+Hg3JNf07AKRfl0V5djoypjQ=="
+    },
+    "shlex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.0.2.tgz",
+      "integrity": "sha512-i4p9nNXgBTILspHwZlBCNsZzwuVWW8SFx5dyIONrjL0R+AbMOPbg7ndqgGfjYivkYRTtZMKqIT8HT+QyOhPQWA=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "run-on-arch",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Multi architecture support for GitHub Actions",
   "author": "Umberto Raimondi, Elijah Shaw-Rutschman",
   "license": "BSD-3-Clause",
   "dependencies": {
     "@actions/core": "^1.1.1",
     "@actions/exec": "^1.0.1",
+    "shlex": "^2.0.2",
     "yaml": "^1.10.0"
   }
 }

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -46,7 +46,10 @@ build_container () {
   # cached between builds.
   if [[ -z "${GITHUB_TOKEN:-}" ]]
   then
-    docker build . --file "$DOCKERFILE" --tag "${CONTAINER_NAME}:latest"
+    docker build \
+      "${ACTION_DIR}/Dockerfiles" \
+      --file "$DOCKERFILE" \
+      --tag "${CONTAINER_NAME}:latest"
   else
     # Build optimization that uses GitHub package registry to cache docker
     # images, based on Thai Pangsakulyanont's experiments.
@@ -64,7 +67,9 @@ build_container () {
     set "$BASH_FLAGS"
 
     docker pull "$PACKAGE_REGISTRY:latest" || true
-    docker build . --file "$DOCKERFILE" \
+    docker build \
+      "${ACTION_DIR}/Dockerfiles" \
+      --file "$DOCKERFILE" \
       --tag "${CONTAINER_NAME}:latest" \
       --cache-from="$PACKAGE_REGISTRY"
     docker tag "${CONTAINER_NAME}:latest" "$PACKAGE_REGISTRY" \

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -61,7 +61,6 @@ build_container () {
     echo "$GITHUB_TOKEN" | docker login docker.pkg.github.com \
       -u "$GITHUB_ACTOR" \
       --password-stdin
-    set -x
     set "$BASH_FLAGS"
 
     docker pull "$PACKAGE_REGISTRY:latest" || true

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -34,7 +34,7 @@ install_deps () {
   # Install support for non-amd64 emulation in Docker via QEMU.
   # Platforms: linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x,
   #            linux/386, linux/arm/v7, linux/arm/v6
-  sudo apt-get update -y
+  sudo apt-get update -q -y
   sudo apt-get -qq install -y qemu qemu-user-static
   docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 }


### PR DESCRIPTION
Some `dockerRunArg` values would fail, due to improper handling of quotes. This is sidestepped by parsing the arguments into an array using `shlex`, then passing that array's items as separate N arguments to `run-on-arch.sh`.

It also seems that the container names must be lower-case, so we ensure the `slug()` function returns a lower-case string. Some GitHub repositories will have upper-case letters.

Edit: I've also added an `install` input parameter, which runs as part of `docker build`. This allows dependency installation to be cached in a docker image layer that persists between builds.