### PR TITLE
Use workflow in container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
     name: Build on ubuntu-18.04 armv7
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.2
+      - uses: uraimo/run-on-arch-action@v2.0.5
         name: Run commands
         id: runcmd
         with:
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.2
+      - uses: uraimo/run-on-arch-action@v2.0.5
         name: Build artifact
         id: build
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![](https://github.com/uraimo/run-on-arch-action/workflows/test/badge.svg)](https://github.com/uraimo/run-on-arch-action)
 
-A GitHub Action that executes commands on non-amd64 CPU architecture (armv6, armv7, aarch64, s390x, ppc64le).
+A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7, aarch64, s390x, ppc64le).
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "run-on-arch",
-  "version": "2.0.2",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-on-arch",
-  "version": "2.0.2",
+  "version": "2.0.5",
   "description": "Multi architecture support for GitHub Actions",
   "author": "Umberto Raimondi, Elijah Shaw-Rutschman",
   "license": "BSD-3-Clause",

--- a/src/run-on-arch.js
+++ b/src/run-on-arch.js
@@ -92,8 +92,11 @@ async function main() {
     });
   }
 
-  // Generate a container name slug unique to this arch/distro combo
-  const containerName = `run-on-arch-${slug(env.GITHUB_REPOSITORY)}-${slug(arch)}-${slug(distro)}`;
+  // Generate a container name slug unique to this workflow
+  const containerName = slug([
+    'run-on-arch', env.GITHUB_REPOSITORY, env.GITHUB_WORKFLOW,
+    arch, distro,
+  ].join('-'));
 
   console.log('Configuring Docker for multi-architecture support')
   await exec(

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -32,7 +32,7 @@ quiet () {
 }
 
 install_deps () {
-  # Install support for non-amd64 emulation in Docker via QEMU.
+  # Install support for non-x86 emulation in Docker via QEMU.
   # Platforms: linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x,
   #            linux/386, linux/arm/v7, linux/arm/v6
   sudo apt-get update -q -y


### PR DESCRIPTION
If a project has multiple `.github/workflows/*.yml` files that make use of `run-on-arch-action`, this change makes sure the workflows don’t clobber each other’s cached docker images.

Also bumps the version to 2.0.5.