### PR TITLE
Add Arch Linux ARM

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -17,6 +17,8 @@ jobs:
             distro: alpine_latest
           - arch: s390x
             distro: fedora_latest
+          - arch: armv7
+            distro: archarm_latest
 
     steps:
       - uses: actions/checkout@v2.1.0
@@ -65,6 +67,9 @@ jobs:
                 apk update
                 apk add git
                 ;;
+              archarm*)
+                pacman -Syyu --noconfirm
+                pacman -S git which --noconfirm
             esac
 
           # Produce a binary artifact and place it in the mounted volume

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
           # The full matrix of Dockerfiles would be extensive, so just
           # cover each arch and OS at least once.
           - arch: aarch64
+            distro: archarm_latest
+          - arch: aarch64
             distro: fedora_latest
           - arch: ppc64le
             distro: alpine_latest
@@ -88,6 +90,11 @@ jobs:
               apk update
               apk add git
               ;;
+            archarm*)
+              pacman -Syyu --noconfirm
+              pacman -S git which --noconfirm
+              ln -s /usr/lib/os-release /etc/os-release
+              ;;
           esac
 
         # Run on container
@@ -136,8 +143,13 @@ jobs:
       run: |
         git_path="${{ steps.build.outputs.git_path }}"
 
-        echo "Assert git path: '$git_path' == '/usr/bin/git'"
-        test "$git_path" == "/usr/bin/git"
+        case "${{ matrix.distro }}" in
+          archarm*) expected_git_path="/usr/sbin/git" ;;
+          *) expected_git_path="/usr/bin/git" ;;
+        esac
+
+        echo "Assert git path: '$git_path' == '$expected_git_path'"
+        test "$git_path" == "$expected_git_path"
 
     - name: Assert job would fail on setup script error
       run: |
@@ -169,6 +181,7 @@ jobs:
           alpine*) distro_key="alpine" ;;
           ubuntu*) distro_key="ubuntu" ;;
           fedora*) distro_key="fedora" ;;
+          archarm*) distro_key="archarm" ;;
           *) distro_key="${{ matrix.distro }}" ;;
         esac
 

--- a/Dockerfiles/Dockerfile.aarch64.archarm_latest
+++ b/Dockerfiles/Dockerfile.aarch64.archarm_latest
@@ -1,0 +1,4 @@
+FROM agners/archlinuxarm-arm64v8:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.archarm_latest
+++ b/Dockerfiles/Dockerfile.armv7.archarm_latest
@@ -1,0 +1,4 @@
+FROM agners/archlinuxarm-arm32v7:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7
 This action requires three input parameters:
 
 * `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
-* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `buster`, `stretch`, `jessie`, `fedora_latest`, or `alpine_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
 The action also accepts some optional input parameters:
@@ -152,8 +152,8 @@ This table details the valid `arch`/`distro` combinations:
 | arch     | distro     |
 | -------- | ---------- |
 | armv6    | jessie, stretch, buster, alpine_latest |
-| armv7    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
-| aarch64  | stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
+| armv7    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
+| aarch64  | stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
 | s390x    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
 | ppc64le  | jessie, stretch, buster, ubuntu16.04, ubuntu18.04,ubuntu20.04, fedora_latest, alpine_latest |
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7
 This action requires three input parameters:
 
 * `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
-* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
 The action also accepts some optional input parameters:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'aarch64'
   distro:
-    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, buster, stretch, jessie, fedora_latest, alpine_latest.'
+    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest.'
     required: false
     default: 'ubuntu18.04'
   githubToken:


### PR DESCRIPTION
Adds support for [Arch Linux ARM](https://archlinuxarm.org/) using Docker images automatically created weekly by https://github.com/agners/archlinuxarm-docker. Both architectures supported by the latter project are included in this PR.

GitHub Actions successfully tested both `armv7` and `aarch64` variants in each of the `advanced-example.yml` and `test.yml` files.

A distro identifier of `archarm` was used to match the `/etc/os-release` variable `ID=archarm`.