### PR TITLE
Add debian:bullseye to aarch64 architecture.

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
 
-    # Run steps on a matrix of 3 arch/distro combinations
+    # Run steps on a matrix of 4 arch/distro combinations
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
             distro: fedora_latest
           - arch: armv7
             distro: ubuntu18.04
+          - arch: aarch64
+            distro: bullseye  
             # Run tests that only need to be run on one matrix node
             run_extra_tests: true
 
@@ -78,7 +80,7 @@ jobs:
         # image layer.
         install: |
           case "${{ matrix.distro }}" in
-            ubuntu*|jessie|stretch|buster)
+            ubuntu*|jessie|stretch|buster|bullseye)
               apt-get update -q -y
               apt-get install -q -y git
               ;;

--- a/Dockerfiles/Dockerfile.aarch64.bullseye
+++ b/Dockerfiles/Dockerfile.aarch64.bullseye
@@ -1,0 +1,4 @@
+FROM arm64v8/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7
 This action requires three input parameters:
 
 * `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
-* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `bullseye`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
 The action also accepts some optional input parameters:
@@ -118,7 +118,7 @@ jobs:
           # no secrets are present in the container state or logs.
           install: |
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster)
+              ubuntu*|jessie|stretch|buster|bullseye)
                 apt-get update -q -y
                 apt-get install -q -y git
                 ;;
@@ -153,7 +153,7 @@ This table details the valid `arch`/`distro` combinations:
 | -------- | ---------- |
 | armv6    | jessie, stretch, buster, alpine_latest |
 | armv7    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
-| aarch64  | stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
+| aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
 | s390x    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
 | ppc64le  | jessie, stretch, buster, ubuntu16.04, ubuntu18.04,ubuntu20.04, fedora_latest, alpine_latest |
 


### PR DESCRIPTION
Adds support for **_debian:bullseye_** using Docker the default docker file `Dockerfile.aarch64.bullseye`.
Only for aarch64 for now since that's the only embedded device I have here (to test a few built artifacts on the device itself) .


I'm running the repository tests [here](https://github.com/leoniloris/run-on-arch-action/pull/1)