### PR TITLE
Add Debian:bullseye to supported architectures.

### DIFF
--- a/Dockerfiles/Dockerfile.armv6.bullseye
+++ b/Dockerfiles/Dockerfile.armv6.bullseye
@@ -1,0 +1,4 @@
+FROM balenalib/rpi-raspbian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.bullseye
+++ b/Dockerfiles/Dockerfile.armv7.bullseye
@@ -1,0 +1,4 @@
+FROM arm32v7/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.bullseye
+++ b/Dockerfiles/Dockerfile.ppc64le.bullseye
@@ -1,0 +1,4 @@
+FROM ppc64le/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.bullseye
+++ b/Dockerfiles/Dockerfile.s390x.bullseye
@@ -1,0 +1,4 @@
+FROM s390x/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ This table details the valid `arch`/`distro` combinations:
 
 | arch     | distro     |
 | -------- | ---------- |
-| armv6    | jessie, stretch, buster, alpine_latest |
-| armv7    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
+| armv6    | jessie, stretch, buster, bullseye, alpine_latest |
+| armv7    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
 | aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
-| s390x    | jessie, stretch, buster, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
-| ppc64le  | jessie, stretch, buster, ubuntu16.04, ubuntu18.04,ubuntu20.04, fedora_latest, alpine_latest |
+| s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
+| ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, fedora_latest, alpine_latest |
 
 
 Using an invalid `arch`/`distro` combination will fail.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'aarch64'
   distro:
-    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest.'
+    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, bullseye, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest.'
     required: false
     default: 'ubuntu18.04'
   githubToken:


### PR DESCRIPTION
Follows #44 and the comment https://github.com/uraimo/run-on-arch-action/pull/44#issuecomment-848616666 as an effort to push a new release

Adds support for **_debian:bullseye_** using the default docker files.

I'm running the repository tests [here](https://github.com/leoniloris/run-on-arch-action/pull/1), but only the tests related to this specific PR (since the added arch:distro combination is not covered on the test.yml).