### PR TITLE
Update `$GITHUB_` and `$RUNNER_` env vars

### DIFF
--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -100,34 +100,29 @@ run_container () {
     --rm \
     -e DEBIAN_FRONTEND=noninteractive \
     -e CI \
-    -e GITHUB_WORKFLOW \
-    -e GITHUB_RUN_ID \
-    -e GITHUB_RUN_NUMBER \
     -e GITHUB_ACTION \
+    -e GITHUB_ACTION_PATH \
     -e GITHUB_ACTIONS \
     -e GITHUB_ACTOR \
-    -e GITHUB_REPOSITORY \
+    -e GITHUB_API_URL \
+    -e GITHUB_BASE_REF \
     -e GITHUB_ENV \
     -e GITHUB_EVENT_NAME \
     -e GITHUB_EVENT_PATH \
-    -e GITHUB_WORKSPACE \
-    -e GITHUB_SHA \
-    -e GITHUB_REF \
-    -e GITHUB_HEAD_REF \
-    -e GITHUB_BASE_REF \
-    -e GITHUB_SERVER_URL \
-    -e GITHUB_API_URL \
     -e GITHUB_GRAPHQL_URL \
-    -e GITHUB_REF \
-    -e GITHUB_SHA \
     -e GITHUB_HEAD_REF \
-    -e GITHUB_BASE_REF \
-    -e GITHUB_EVENT_NAME \
+    -e GITHUB_JOB \
+    -e GITHUB_REF \
+    -e GITHUB_REPOSITORY \
+    -e GITHUB_RUN_ID \
+    -e GITHUB_RUN_NUMBER \
+    -e GITHUB_SERVER_URL \
+    -e GITHUB_SHA \
+    -e GITHUB_WORKFLOW \
     -e GITHUB_WORKSPACE \
-    -e GITHUB_EVENT_PATH \
     -e RUNNER_OS \
-    -e RUNNER_TOOL_CACHE \
     -e RUNNER_TEMP \
+    -e RUNNER_TOOL_CACHE \
     -e RUNNER_WORKSPACE \
     -v "/var/run/docker.sock:/var/run/docker.sock" \
     -v "${EVENT_DIR}:${EVENT_DIR}" \

--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -107,6 +107,7 @@ run_container () {
     -e GITHUB_ACTIONS \
     -e GITHUB_ACTOR \
     -e GITHUB_REPOSITORY \
+    -e GITHUB_ENV \
     -e GITHUB_EVENT_NAME \
     -e GITHUB_EVENT_PATH \
     -e GITHUB_WORKSPACE \
@@ -124,6 +125,7 @@ run_container () {
     -e GITHUB_EVENT_NAME \
     -e GITHUB_WORKSPACE \
     -e GITHUB_EVENT_PATH \
+    -e RUNNER_OS \
     -e RUNNER_TOOL_CACHE \
     -e RUNNER_TEMP \
     -e RUNNER_WORKSPACE \


### PR DESCRIPTION
This PR updates the list of `$GITHUB_` and `$RUNNER_` environment variables that are passed into the Docker environment according to the [official docs](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).

Fixes #52 (/cc @marceltaeumel)