### PR TITLE
Add several architectures and their debian images

### DIFF
--- a/Dockerfile.amd64.buster
+++ b/Dockerfile.amd64.buster
@@ -1,0 +1,4 @@
+FROM amd64/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfile.mips64le.buster
+++ b/Dockerfile.mips64le.buster
@@ -1,0 +1,4 @@
+FROM mips64le/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.amd64.bullseye
+++ b/Dockerfiles/Dockerfile.amd64.bullseye
@@ -1,0 +1,4 @@
+FROM amd64/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.i386.bullseye
+++ b/Dockerfiles/Dockerfile.i386.bullseye
@@ -1,0 +1,4 @@
+FROM i386/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.i386.buster
+++ b/Dockerfiles/Dockerfile.i386.buster
@@ -1,0 +1,4 @@
+FROM i386/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.mips64le.bullseye
+++ b/Dockerfiles/Dockerfile.mips64le.bullseye
@@ -1,0 +1,4 @@
+FROM mips64le/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.riscv64.bullseye
+++ b/Dockerfiles/Dockerfile.riscv64.bullseye
@@ -1,0 +1,4 @@
+FROM riscv64/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.riscv64.buster
+++ b/Dockerfiles/Dockerfile.riscv64.buster
@@ -1,0 +1,4 @@
+FROM riscv64/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7
 
 This action requires three input parameters:
 
-* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, `ppc64le`, `i386`, `amd64`, `mips64le`, or `riscv64`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `bullseye`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
@@ -154,6 +154,10 @@ This table details the valid `arch`/`distro` combinations:
 | aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest, archarm_latest |
 | s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, fedora_latest, alpine_latest |
 | ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, fedora_latest, alpine_latest |
+| amd64    | buster, bullseye |
+| i386     | buster, bullseye |
+| mips64le | buster, bullseye |
+| riscv64  | buster, bullseye |
 
 
 Using an invalid `arch`/`distro` combination will fail.


### PR DESCRIPTION
This pull request adds buster and bullseye debian for riscv64, mips64le, i386 and amd64(I know, that i386 and amd64 you can use without this, but with this action, it is much easier to build several platforms.