### PR TITLE
Add i386 images for alpine_latest and bullseye

### DIFF
--- a/Dockerfiles/Dockerfile.i386.alpine_latest
+++ b/Dockerfiles/Dockerfile.i386.alpine_latest
@@ -1,0 +1,4 @@
+FROM 386/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.i386.bullseye
+++ b/Dockerfiles/Dockerfile.i386.bullseye
@@ -1,0 +1,4 @@
+FROM 386/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh


### PR DESCRIPTION
Closes #57. I've only added two platforms, as they're the ones I need, but I can add more if necessary.