### PR TITLE
Pass arch to docker

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -9,6 +9,7 @@ jobs:
 
     # Run steps on a matrix of 4 arch/distro combinations
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     name: Test
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           # The full matrix of Dockerfiles would be extensive, so just

--- a/Dockerfiles/Dockerfile.aarch64.archarm_latest
+++ b/Dockerfiles/Dockerfile.aarch64.archarm_latest
@@ -1,4 +1,4 @@
-FROM agners/archlinuxarm-arm64v8:latest
+FROM danhunsaker/archlinuxarm-arm64v8:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.archarm_latest
+++ b/Dockerfiles/Dockerfile.armv7.archarm_latest
@@ -1,4 +1,4 @@
-FROM agners/archlinuxarm-arm32v7:latest
+FROM danhunsaker/archlinuxarm-arm32v7:latest
 
 COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
 RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/src/run-on-arch.js
+++ b/src/run-on-arch.js
@@ -9,6 +9,19 @@ function slug(str) {
   return str.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
 }
 
+function docker_arch(qemu_arch) {
+  const matrix = {
+    'i386':    '386',
+    'x86_64':  'amd64',
+    'armv5':   'arm/v5',
+    'armv6':   'arm/v6',
+    'armv7':   'arm/v7',
+    'aarch64': 'arm64',
+  };
+  
+  return matrix[qemu_arch] || qemu_arch;
+}
+
 async function main() {
   if (process.platform !== 'linux') {
     throw new Error('run-on-arch supports only Linux')
@@ -101,7 +114,7 @@ async function main() {
   console.log('Configuring Docker for multi-architecture support')
   await exec(
     path.join(__dirname, 'run-on-arch.sh'),
-    [ dockerFile, containerName, ...dockerRunArgs ],
+    [ docker_arch(arch), dockerFile, containerName, ...dockerRunArgs ],
     { env },
   );
 }


### PR DESCRIPTION
This PR does a couple of things. Primarily, it passes the target architecture to the various Docker commands so that it will stop complaining about not being told in advance. (resolves #21). Secondarily, it groups output lines for easier debugging and suchforth (resolves #62).

As an added bonus, it switches to a fork of archarm with more recent images, which solves the issue seen in testing and downstream use cases where a full system upgrade refuses to complete due to insufficient storage space (resolves #48). This part is expected to be reverted once the upstream merges agners/archlinuxarm_docker#8 and their own builds resume, but who knows how long that might take. The expected reversion is why it's in its own commit, here.