### PR TITLE
Feature: floating tag (fixes #64)

### DIFF
--- a/.github/workflows/floating-tag.yml
+++ b/.github/workflows/floating-tag.yml
@@ -1,0 +1,29 @@
+name: Update floating tag
+
+on:
+  push:
+    tags:
+      # Only match vXX.YY.ZZ tags
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    name: Update floating tag
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fregante/setup-git-user@v1
+      - name: Tag and push
+        run: |
+          # Parse tag name, e.g. "v2" from "refs/tags/v2.22.12"
+          parse='import sys; print(sys.argv[1].split("/")[-1].split(".")[0])'
+          tag=$(python -c "$parse" "$GITHUB_REF")
+
+          # Empty commit that skips CI to prevent the `[remote rejected]` error.
+          # Error is due to the default GITHUB_TOKEN not having the `workflows`
+          # permission. Also prevents unnecessary test runs.
+          git commit --allow-empty -m "Tagged $tag from $GITHUB_REF [skip ci]"
+
+          # Overwrite tag
+          git tag -f "$tag"
+          git push -f origin "$tag"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     name: Build on ubuntu-18.04 armv7
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2
         name: Run commands
         id: runcmd
         with:
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2
         name: Build artifact
         id: build
         with:

--- a/src/run-on-arch.js
+++ b/src/run-on-arch.js
@@ -40,10 +40,17 @@ async function main() {
       shell = '/bin/bash';
     }
   }
+  let installShell;
+  if (/alpine/.test(distro)) {
+    // Alpine has busybox and must use /bin/sh at least for installation.
+    installShell = '/bin/sh';
+  } else {
+    installShell = shell;
+  }
 
   // Write install commands to a script file for running in the Dockerfile
   const install = [
-    `#!${shell}`, 'set -eu;', 'export DEBIAN_FRONTEND=noninteractive;',
+    `#!${installShell}`, 'set -eu;', 'export DEBIAN_FRONTEND=noninteractive;',
     core.getInput('install'),
   ].join('\n');
   fs.writeFileSync(


### PR DESCRIPTION
Hey @uraimo, hope you are well!

Support for floating tags, such as `uses: uraimo/run-on-arch-action@v2` instead of `uses: uraimo/run-on-arch-action@v2.1.0`. The documentation has been updated accordingly.

Floating tags will be automatically updated whenever a tag matching `v[0-9]+.[0-9]+.[0-9]+` is pushed.

Additionally, a small fix is included which ensures that the `install` step for Alpine uses `/bin/sh`, since that will be the only shell available.