### PR TITLE
Bump version to 2.1.1 in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     name: Build on ubuntu-18.04 armv7
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.1.1
         name: Run commands
         id: runcmd
         with:
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.1.1
         name: Build artifact
         id: build
         with:


### PR DESCRIPTION
Newcomers like me will copy-paste the readme and use a recent distro (like `bullseye` on `armv7`) and this does not work with `2.0.5` so bumping to lastest.