### PR TITLE
Run Docker so qemu-aarch64 flags: OCF (fixes uraimo#68)

### DIFF
--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -37,7 +37,7 @@ install_deps () {
   #            linux/386, linux/arm/v7, linux/arm/v6
   sudo apt-get update -q -y
   sudo apt-get -qq install -y qemu qemu-user-static
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
 }
 
 build_container () {


### PR DESCRIPTION
This PR resolves issue #68.

The root cause of the `sudo: effective uid is not 0, is /usr/sbin/sudo on a file system with the 'nosuid' option set or an NFS file system without root privileges?` error is explained in https://github.com/multiarch/qemu-user-static/issues/17. 

In summary the QEMU Docker instance needs to launched so the `binfmt_misc` flags include `OCF`. Prior to this PR the flags are limited to `F`, which can be confirmed using following `run-on-arch-action` configuration:

```yaml
  setup: |
    cat /proc/sys/fs/binfmt_misc/qemu-aarch64
```

This returns:

```
enabled
interpreter /usr/bin/qemu-aarch64-static
flags: F
offset 0
magic 7f454c460201010000000000000000000200b700
mask ffffffffffffff00fffffffffffffffffeffffff
```

Applying the PR results in:

```
enabled
interpreter /usr/bin/qemu-aarch64-static
flags: OCF
offset 0
magic 7f454c460201010000000000000000000200b700
mask ffffffffffffff00fffffffffffffffffeffffff
```

`sudo` now works in `run-on-arch-action` containers.