### PR TITLE
Add Manjaro Linux support for aarch64

### DIFF
--- a/Dockerfiles/Dockerfile.aarch64.manjarolinux_latest
+++ b/Dockerfiles/Dockerfile.aarch64.manjarolinux_latest
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm64 manjarolinux/base:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This table details the valid `arch`/`distro` combinations:
 | -------- | ---------- |
 | armv6    | jessie, stretch, buster, bullseye, alpine_latest |
 | armv7    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
-| aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
+| aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest, manjarolinux_latest |
 | s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
 | ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'aarch64'
   distro:
-    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, bullseye, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest.'
+    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, bullseye, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest, manjarolinux_latest.'
     required: false
     default: 'ubuntu18.04'
   githubToken:


### PR DESCRIPTION
Add support for official Manjaro Linux Docker image ( https://github.com/manjaro/manjaro-docker )

# Summary

Since PR #47 has gone stale, I decided to approach the issue myself.

After evaluation of approach presented in [previous PR comment](https://servicelab.org/2018/09/13/platform-aware-docker-images/) versus [the official way via BuildX](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) I saw specifying target platform inside the `Dockerfile` as a proper solution in comparison to changing GitHub Actions of the official images to provide the image under new tags.

This however generates a warning which is a small price to pay for otherwise functional image.
See [my GitHub Action result](https://github.com/AlexTalker/gh-actions-playground/runs/6543711850) for the example.

If needed, specifying `--platform` for `docker build` and `docker run` might be wrapped in separate PR as I see it,
especially since I don't have full list of supported values for it.