### PR TITLE
Add manylinux 2_24 & 2_28

### DIFF
--- a/Dockerfiles/Dockerfile.aarch64.manylinux_2_24
+++ b/Dockerfiles/Dockerfile.aarch64.manylinux_2_24
@@ -1,0 +1,4 @@
+FROM quay.io/pypa/manylinux_2_24_aarch64
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.aarch64.manylinux_2_28
+++ b/Dockerfiles/Dockerfile.aarch64.manylinux_2_28
@@ -1,0 +1,4 @@
+FROM quay.io/pypa/manylinux_2_28_aarch64
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.manylinux_2_24
+++ b/Dockerfiles/Dockerfile.ppc64le.manylinux_2_24
@@ -1,0 +1,4 @@
+FROM quay.io/pypa/manylinux_2_24_ppc64le
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.manylinux_2_28
+++ b/Dockerfiles/Dockerfile.ppc64le.manylinux_2_28
@@ -1,0 +1,4 @@
+FROM quay.io/pypa/manylinux_2_28_ppc64le
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.manylinux_2_24
+++ b/Dockerfiles/Dockerfile.s390x.manylinux_2_24
@@ -1,0 +1,4 @@
+FROM quay.io/pypa/manylinux_2_24_s390x
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ This table details the valid `arch`/`distro` combinations:
 | -------- | ---------- |
 | armv6    | jessie, stretch, buster, bullseye, alpine_latest |
 | armv7    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
-| aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
-| s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
-| ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
+| aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest, manylinux_2_24, manylinux_2_28 |
+| s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, manylinux_2_24 |
+| ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, manylinux_2_24, manylinux_2_28 |
 
 
 Using an invalid `arch`/`distro` combination will fail.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: 'aarch64'
   distro:
-    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, bullseye, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest.'
+    description: 'Linux distribution name: ubuntu16.04, ubuntu18.04, ubuntu20.04, bullseye, buster, stretch, jessie, fedora_latest, alpine_latest, archarm_latest, manylinux_2_24, manylinux_2_28.'
     required: false
     default: 'ubuntu18.04'
   githubToken:


### PR DESCRIPTION
Hi,

Thanks for this super nice project !

This PR add support for the https://github.com/pypa/manylinux distribution.
This allows to create binary python wheels and upload them to PyPI through github action.

Here is an example: https://github.com/cmake-wheel/cmeel-example/blob/main/.github/workflows/release.yml
And the corresponding published package: https://pypi.org/project/cmeel-example/#files

Cheers !