### PR TITLE
Support `x86_64` aka `amd64` arch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
             distro: fedora_latest
           - arch: ppc64le
             distro: alpine_latest
+          - arch: x86_64
+            distro: ubuntu_latest
           - arch: armv6
             distro: buster
           - arch: armv7

--- a/Dockerfiles/Dockerfile.x86_64.alpine_latest
+++ b/Dockerfiles/Dockerfile.x86_64.alpine_latest
@@ -1,0 +1,4 @@
+FROM amd64/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.bullseye
+++ b/Dockerfiles/Dockerfile.x86_64.bullseye
@@ -1,0 +1,4 @@
+FROM amd64/debian:bullseye
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.buster
+++ b/Dockerfiles/Dockerfile.x86_64.buster
@@ -1,0 +1,4 @@
+FROM amd64/debian:buster
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.fedora_latest
+++ b/Dockerfiles/Dockerfile.x86_64.fedora_latest
@@ -1,0 +1,4 @@
+FROM amd64/fedora:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.jessie
+++ b/Dockerfiles/Dockerfile.x86_64.jessie
@@ -1,0 +1,4 @@
+FROM amd64/debian:jessie
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.stretch
+++ b/Dockerfiles/Dockerfile.x86_64.stretch
@@ -1,0 +1,4 @@
+FROM amd64/debian:stretch
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu16.04
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu16.04
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:16.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu18.04
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu18.04
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:18.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu20.04
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu20.04
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:20.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu22.04
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:22.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu_devel
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu_devel
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:devel
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu_latest
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu_latest
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.x86_64.ubuntu_rolling
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu_rolling
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:rolling
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7
 
 This action requires three input parameters:
 
-* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `s390x`, `ppc64le`, or `x86_64`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `distro`: Linux distribution name: `ubuntu16.04`, `ubuntu18.04`, `ubuntu20.04`, `bullseye`, `buster`, `stretch`, `jessie`, `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
@@ -154,6 +154,7 @@ This table details the valid `arch`/`distro` combinations:
 | aarch64  | stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
 | s390x    | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
 | ppc64le  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04,ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
+| x86_64  | jessie, stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest |
 
 
 Using an invalid `arch`/`distro` combination will fail.

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ description: 'Run commands in a Linux container with a specific CPU architecture
 author: 'Umberto Raimondi, Elijah Shaw-Rutschman'
 inputs:
   arch:
-    description: 'CPU architecture: armv6, armv7, aarch64, s390x, ppc64le.'
+    description: 'CPU architecture: armv6, armv7, aarch64, s390x, ppc64le, x86_64.'
     required: false
     default: 'aarch64'
   distro:


### PR DESCRIPTION
Actions using the `amd64` arch will not actually use Qemu to run things.
But it makes user's lifes easier by removing the need for special-casing _no_ emulation builds.

The Dockerfiles use the https://hub.docker.com/u/amd64/ organization's containers as base.

Closes https://github.com/uraimo/run-on-arch-action/issues/93.