### PR TITLE
Fixes #55 - Use both the workflow and job names in the container name

### DIFF
--- a/src/run-on-arch.js
+++ b/src/run-on-arch.js
@@ -102,7 +102,7 @@ async function main() {
   // Generate a container name slug unique to this workflow
   const containerName = slug([
     'run-on-arch', env.GITHUB_REPOSITORY, env.GITHUB_WORKFLOW,
-    arch, distro,
+    env.GITHUB_JOB, arch, distro,
   ].join('-'));
 
   console.log('Configuring Docker for multi-architecture support')


### PR DESCRIPTION
This PR fixes #55 .
Now the Docker container name will contain the job id as well.
This makes it possible to use run-on-arch-action in several jobs in the same workflow.

Note: After this change the build cache will be invalidated for each project that uses the new version! 