### PR TITLE
Allow overriding the containerName

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The action also accepts some optional input parameters:
 * `setup`: Shell commands to execute on the host before running the container, such as creating directories for volume mappings.
 * `install`: Shell commands to execute in the container as part of `docker build`, such as installing dependencies. This speeds up subsequent builds if `githubToken` is also used, but note that the image layer will be publicly available in your projects GitHub Package Registry, so make sure the resulting image does not have any secrets cached in logs or state.
 * `base_image`: Specify a custom base image, such as [busybox](https://hub.docker.com/_/busybox), `arch` and `distro` should be set to `none` in this case. This will allow you to chose direcly the image that will be used in the *FROM* clause of the internal docker container without needing to create a Dockerfile.arch.distro for a specific arch/distro pair. For more detials, see [PR #103](https://github.com/uraimo/run-on-arch-action/pull/103#issuecomment-1363810049). Known limitation: Only one base_image configuration for each workflow if you use GitHub images caching.
-
+* `cachedImageTag`: Allows to override the image tag that is used when caching Docker images in your project's public package registry. It is coerced to adhere to the [specification](https://docs.docker.com/engine/reference/commandline/tag/).
 ### Basic example
 
 A basic example that sets an output variable for use in subsequent steps:

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,12 @@ inputs:
     description: 'Specify a custom base image, such as \"busybox\" or your predefined base image. This will replace the \"FROM\" claus in the default Dockerfile on the fly. This is optional. Hint: with this option you are able to use all the available archs other than the ones showed by default. See the [advanced example](./.github/workflows/advanced-example.yml) in this repo. For more detials, see [PR #103](https://github.com/uraimo/run-on-arch-action/pull/103#issuecomment-1363810049).'
     required: false
     default: ''
+  cachedImageTag:
+    description: 'Allows overriding the name image tag that is used for caching Docker images. It is coerced to
+      adhere to the [specification](https://docs.docker.com/engine/reference/commandline/tag/).'
+    required: false
+    default: ''
+
 
 runs:
   using: 'node16'


### PR DESCRIPTION
This PR adds a new optional parameter ``cachedImageTag`` which allows overriding the otherwise
automatically generated image tag.  Reading #55 #100 and #56, I came to the conclusion, that having
the freedom to completely override the image tag would be most useful. There are also 2 other usecases for this:

- The default naming is not very userfriendly. After all, the image tags are published as "packages" in the repository of the invoker. Therefore it is desirable to have a self-explatatory name. For example in [this](https://github.com/felfert/cherryrgb-rs) project, I create a rust toolchain with one additional build dependency. This is useful for other projects too, so I want the name to reflect this.
- Sometimes one **DOES** want to share an image between different workflows or run names which is currently not possible.

One additional change was made:
The slug() function does not strictly adhere to [the spec](https://docs.docker.com/engine/reference/commandline/tag/). See comments in ``src/run-on-arch.js``, for an explanation, why I deliberately still deviate from that (but now it is still closer to the spec).

Would be appreciated, if this could be considered for inclusion in #98

Cheers
 -Fritz