### PR TITLE
Fix reusing cached Docker image

### DIFF
--- a/src/run-on-arch.sh
+++ b/src/run-on-arch.sh
@@ -72,7 +72,8 @@ build_container () {
       "${ACTION_DIR}/Dockerfiles" \
       --file "$DOCKERFILE" \
       --tag "${CONTAINER_NAME}:latest" \
-      --cache-from="$PACKAGE_REGISTRY"
+      --cache-from="$PACKAGE_REGISTRY" \
+      --build-arg BUILDKIT_INLINE_CACHE=1
     docker tag "${CONTAINER_NAME}:latest" "$PACKAGE_REGISTRY" \
       && docker push "$PACKAGE_REGISTRY" || true
   fi


### PR DESCRIPTION
This PR passes `--build-arg BUILDKIT_INLINE_CACHE=1` to Docker
Fixes https://github.com/uraimo/run-on-arch-action/issues/132
Based on https://github.com/kleisauke/libvips-packaging/commit/e0b8d3218bc79f4f333280b8cb907169dccd6af8:
>GitHub Actions has upgraded Docker to version 23, now employing
BuildKit as the default builder in place of the legacy builder:
https://github.com/actions/runner-images/pull/8003
> However, BuildKit doesn't include the information needed to reuse
images for caching. Use the `--build-arg BUILDKIT_INLINE_CACHE=1`
flag to fix this.

Thanks @bashonly for finding that commit, and @grub4k for helping me debug my PR