### PR TITLE
docker: add ubuntu24.04 explicit version

### DIFF
--- a/Dockerfiles/Dockerfile.aarch64.ubuntu24.04
+++ b/Dockerfiles/Dockerfile.aarch64.ubuntu24.04
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm64 arm64v8/ubuntu:24.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.armv7.ubuntu24.04
+++ b/Dockerfiles/Dockerfile.armv7.ubuntu24.04
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm/v7 arm32v7/ubuntu:24.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.ppc64le.ubuntu24.04
+++ b/Dockerfiles/Dockerfile.ppc64le.ubuntu24.04
@@ -1,0 +1,4 @@
+FROM --platform=linux/ppc64le ppc64le/ubuntu:24.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.riscv64.ubuntu24.04
+++ b/Dockerfiles/Dockerfile.riscv64.ubuntu24.04
@@ -1,0 +1,4 @@
+FROM --platform=linux/riscv64 riscv64/ubuntu:24.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/Dockerfiles/Dockerfile.s390x.ubuntu24.04
+++ b/Dockerfiles/Dockerfile.s390x.ubuntu24.04
@@ -1,0 +1,4 @@
+FROM --platform=linux/s390x s390x/ubuntu:24.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh


### PR DESCRIPTION
Allows usage of distro: ubuntu24.04 in gha
Currently fails - though latest is technically
using this ubuntu version