### PR TITLE
ci: Bump numerous `action` revisions

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -29,7 +29,7 @@ jobs:
             base_image: --platform=linux/riscv64 riscv64/ubuntu:24.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./ # If copying this example, change this to uraimo/run-on-arch-action@vX.Y.Z
         name: Build artifact
         id: build

--- a/.github/workflows/basic-example.yml
+++ b/.github/workflows/basic-example.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Build on ubuntu-22.04 armv7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@master
         name: Run commands
         id: runcmd

--- a/.github/workflows/floating-tag.yml
+++ b/.github/workflows/floating-tag.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Update floating tag
     steps:
-      - uses: actions/checkout@v3
-      - uses: fregante/setup-git-user@v1
+      - uses: actions/checkout@v4
+      - uses: fregante/setup-git-user@v2
       - name: Tag and push
         run: |
           # Parse tag name, e.g. "v2" from "refs/tags/v2.22.12"

--- a/.github/workflows/issue160.yml
+++ b/.github/workflows/issue160.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@master
         name: Test
         id: runcmd

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build and run container
       id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build and run container
       id: build


### PR DESCRIPTION
* Bumped `actions/checkout` -> `v4`
* Bumped `fregante/setup-git-user` -> `v2`