### PR TITLE
DEP: upgrade node.js to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,5 +45,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'src/run-on-arch.js'


### PR DESCRIPTION
[Github is deprecating node 20 for GHA runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and will switch to v24 in a couple months.