### PR TITLE
Bumped `actions/checkout` -> `v6` (node24 compatibility)

### DIFF
--- a/.github/workflows/advanced-example.yml
+++ b/.github/workflows/advanced-example.yml
@@ -23,7 +23,7 @@ jobs:
             base_image: --platform=linux/riscv64 riscv64/ubuntu:24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./ # If copying this example, change this to uraimo/run-on-arch-action@vX.Y.Z
         name: Build artifact
         id: build

--- a/.github/workflows/floating-tag.yml
+++ b/.github/workflows/floating-tag.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update floating tag
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: fregante/setup-git-user@v2
       - name: Tag and push
         run: |

--- a/.github/workflows/issue160.yml
+++ b/.github/workflows/issue160.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: uraimo/run-on-arch-action@master
         name: Test
         id: runcmd

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build and run container
       id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build and run container
       id: build


### PR DESCRIPTION
* Bumped `actions/checkout` -> `v6` (node24 compatibility)

Addresses:
>Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4.