### PR TITLE
Add loongarch64 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             distro: trixie
           - arch: ppc64le
             distro: alpine_latest
+          - arch: loongarch64
+            distro: alpine_latest
           - arch: riscv64
             distro: ubuntu22.04
             # Run tests that only need to be run on one matrix node

--- a/Dockerfiles/Dockerfile.loongarch64.alpine_latest
+++ b/Dockerfiles/Dockerfile.loongarch64.alpine_latest
@@ -1,0 +1,4 @@
+FROM --platform=linux/loong64 registry.alpinelinux.org/img/alpine:latest
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 [![](https://github.com/uraimo/run-on-arch-action/workflows/test/badge.svg)](https://github.com/uraimo/run-on-arch-action)
 
 
-A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7, aarch64, s390x, ppc64le) via QEMU.
+A GitHub Action that executes commands on non-x86 CPU architecture (armv6, armv7, aarch64, loongarch64, s390x, ppc64le) via QEMU.
 
 ## Usage
 
 This action requires three input parameters:
 
-* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `riscv64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
+* `arch`: CPU architecture: `armv6`, `armv7`, `aarch64`, `loongarch64`, `riscv64`, `s390x`, or `ppc64le`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `distro`: Linux distribution name: `ubuntu24.04`,`ubuntu22.04`,`ubuntu20.04`, `bookworm`,`bullseye`, `buster`, `stretch`,  `fedora_latest`, `alpine_latest` or `archarm_latest`. See [Supported Platforms](#supported-platforms) for the full matrix.
 * `run`: Shell commands to execute in the container.
 
@@ -162,6 +162,7 @@ This table details the valid `arch`/`distro` combinations:
 | armv6    | stretch, buster, bullseye, bookworm, alpine_latest |
 | armv7    | stretch, buster, bullseye, bookworm, ubuntu20.04, ubuntu22.04 ubuntu24.04,, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
 | aarch64  | stretch, buster, bullseye, bookworm, ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, fedora_latest, alpine_latest, archarm_latest |
+| loongarch64 | alpine_latest |
 | riscv64  | ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, alpine_edge |
 | s390x    | stretch, buster, bullseye, bookworm, ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, alpine_latest |
 | ppc64le  | stretch, buster, bullseye, bookworm, ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest, ubuntu_rolling, ubuntu_devel, alpine_latest |
@@ -171,7 +172,7 @@ Using an invalid `arch`/`distro` combination will fail.
 
 ## Architecture emulation
 
-This project makes use of an additional QEMU container to be able to emulate via software architectures like ARM, s390x, ppc64le, etc... that are not natively supported by GitHub. You should keep this into consideration when reasoning about the expected running time of your jobs, there will be a visible impact on performance when compared to a job executed on a vanilla runner.
+This project makes use of an additional QEMU container to be able to emulate via software architectures like ARM, LoongArch64, s390x, ppc64le, etc... that are not natively supported by GitHub. You should keep this into consideration when reasoning about the expected running time of your jobs, there will be a visible impact on performance when compared to a job executed on a vanilla runner.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -2,11 +2,11 @@ name: 'Run on architecture'
 branding:
   icon: 'cpu'
   color: 'green'
-description: 'Run commands in a Linux container with a specific CPU architecture (armv6, armv7, aarch64, s390x, ppc64le)'
+description: 'Run commands in a Linux container with a specific CPU architecture (armv6, armv7, aarch64, loongarch64, s390x, ppc64le)'
 author: 'Umberto Raimondi, Elijah Shaw-Rutschman'
 inputs:
   arch:
-    description: 'CPU architecture: armv6, armv7, aarch64, riscv64, s390x, ppc64le.'
+    description: 'CPU architecture: armv6, armv7, aarch64, loongarch64, riscv64, s390x, ppc64le.'
     required: false
     default: 'aarch64'
   distro:


### PR DESCRIPTION
  ## Summary

  Add initial LoongArch64 support using the official Alpine image.

  - Add `Dockerfile.loongarch64.alpine_latest`
  - Add `loongarch64/alpine_latest` to the CI matrix
  - Document `loongarch64` in the action metadata and README
  - Keep the existing `tonistiigi/binfmt --install all` setup unchanged

  ## Implementation

  The action architecture name is `loongarch64`, while the corresponding OCI platform is `linux/loong64`.

  The base image comes from the official Alpine registry:

  ```text
  registry.alpinelinux.org/img/alpine:latest
 ```

  The official tonistiigi/binfmt image already supports LoongArch64 through loong64, as added in tonistiigi/binfmt#151
  (https://github.com/tonistiigi/binfmt/pull/151). No additional binfmt image or architecture-specific runtime logic is required.

  ## Validation

  Validated locally on an x86_64 host using QEMU:

  - Confirmed the official Alpine manifest contains linux/loong64
  - Built the new Dockerfile successfully
  - Confirmed uname -m returns loongarch64
  - Successfully ran apk update and apk add git
  - Confirmed Git runs correctly inside the container
  - Passed JavaScript and Shell syntax checks
  - Passed YAML parsing and git diff --check